### PR TITLE
position dropdown dots correctly, add color and z-index

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -21,13 +21,17 @@
         .UserCard-controls {
             // delete important rule once those rules in core files by flarum are removed
             position: relative !important;
-            z-index: 999;
+            z-index: auto;
         }
 
         .Button {
             @media @phone {
                 color: #fff !important;
             }
+        }
+        .Dropdown-menu {
+            // for not overlapping header 
+            z-index: 999;
         }
     }
 }

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -17,5 +17,17 @@
         .UserCard-identity {
             font-size: 22px;
         }
+
+        .UserCard-controls {
+            // delete important rule once those rules in core files by flarum are removed
+            position: relative !important;
+            z-index: 999;
+        }
+
+        .Button {
+            @media @phone {
+                color: #fff !important;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #26

- position dropdown dots correctly in each user card due to being overwritten by an important rule in a core file
- decrease z-index for not overlapping  navigation panel
- add color due to being overwritten by an important rule in a core file

 